### PR TITLE
fix(*): linux container permission issue [KHCP-3788]

### DIFF
--- a/konnect-runtime-setup.sh
+++ b/konnect-runtime-setup.sh
@@ -254,7 +254,8 @@ basicConstraints       = CA:false
 extendedKeyUsage       = clientAuth
 EOF
 
-    openssl req -new -config openssl.cnf -extensions v3_req -days 3650 -newkey rsa:4096 -nodes -x509 -keyout cluster.key -out cluster.crt 
+    openssl req -new -config openssl.cnf -extensions v3_req -days 3650 -newkey rsa:4096 -nodes -x509 -keyout cluster.key -out cluster.crt
+    chmod o+r cluster.key
     CERTIFICATE=$(awk '{printf "%s\\n", $0}' cluster.crt)
     PAYLOAD="{\"name\":\"$KONNECT_CP_NAME\",\"certificates\":[\"$CERTIFICATE\"],\"id\":\"$KONNECT_CP_ID\"}"    
     echo $PAYLOAD > payload.json


### PR DESCRIPTION
Currently this script can not start container on linux machine because of permission issue.

This fix adds read permission to others on `cluster.key`.

ref: https://konghq.atlassian.net/browse/KHCP-3788