### PR TITLE
Open https port for docker container on 8443 by default [KHCP-4308]

### DIFF
--- a/konnect-runtime-setup.sh
+++ b/konnect-runtime-setup.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 KONNECT_RUNTIME_PORT=8000
+KONNECT_RUNTIME_PORT_SECURE=8443
 KONNECT_API_URL=
 KONNECT_USERNAME=
 KONNECT_PASSWORD=
@@ -93,6 +94,10 @@ parse_args() {
         ;;
     -pp)
         KONNECT_RUNTIME_PORT=$2
+        shift
+        ;;
+    -ps)
+        KONNECT_RUNTIME_PORT_SECURE=$2
         shift
         ;;
     -v)
@@ -323,6 +328,7 @@ run_kong() {
         -e "KONG_LUA_SSL_TRUSTED_CERTIFICATE=system,/config/cluster.crt" \
         --mount type=bind,source="$(pwd)",target=/config,readonly \
         -p "$KONNECT_RUNTIME_PORT":8000 \
+        -p "$KONNECT_RUNTIME_PORT_SECURE":8443 \
         "$KONNECT_RUNTIME_REPO"/"$KONNECT_RUNTIME_IMAGE"
 
     if [[ $? -gt 0 ]]; then


### PR DESCRIPTION
Currently this script only exposes HTTP traffic on port 8000.  After this change, port 8000 (HTTP) and 8443 (HTTPS) are exposed by default.

https://konghq.atlassian.net/browse/KHCP-4308

Signed-off-by: Ross Kukulinski <ross@kukulinski.com>