### PR TITLE
feat(quick-start): remove username and password from runtime setup [KHCP-3984]

### DIFF
--- a/konnect-runtime-setup.sh
+++ b/konnect-runtime-setup.sh
@@ -2,15 +2,11 @@
 
 KONNECT_RUNTIME_PORT=8000
 KONNECT_RUNTIME_PORT_SECURE=8443
-KONNECT_API_URL=
-KONNECT_USERNAME=
-KONNECT_PASSWORD=
+KONNECT_CERTIFICATE_KEY=
 KONNECT_CONTROL_PLANE=
 KONNECT_RUNTIME_REPO=
 KONNECT_RUNTIME_IMAGE=
 
-KONNECT_CP_ID=
-KONNECT_CP_NAME=
 KONNECT_CP_ENDPOINT=
 KONNECT_TP_ENDPOINT=
 KONNECT_HTTP_SESSION_NAME="konnect-session"
@@ -50,12 +46,12 @@ cat << EOF
 Usage: konnect-runtime-setup [options ...]
 
 Options:
-    -api            Konnect API
-    -u              Konnect username
-    -p              Konnect user password
+    -key            Konnect certificate key
     -c              Konnect control plane Id
     -r              Konnect runtime repository url
     -ri             Konnect runtime image name
+    -cp             Konnect control plane outlet url
+    -te             Konnect telemetry endpoint url
     -pp             runtime port number
     -v              verbose mode
     -h, --help      display help text
@@ -68,16 +64,8 @@ parse_args() {
   while [[ $# -gt 0 ]]; do
     key="$1"
     case $key in
-    -api)
-        KONNECT_API_URL=$2
-        shift
-        ;;
-    -u)
-        KONNECT_USERNAME=$2
-        shift
-        ;;
-    -p)
-        KONNECT_PASSWORD=$2
+    -key)
+        KONNECT_CERTIFICATE_KEY=$2
         shift
         ;;
     -c)
@@ -90,6 +78,14 @@ parse_args() {
         ;;
     -ri)
         KONNECT_RUNTIME_IMAGE=$2
+        shift
+        ;;
+    -cp)
+        KONNECT_CP_ENDPOINT=$2
+        shift
+        ;;
+    -te)
+        KONNECT_TP_ENDPOINT=$2
         shift
         ;;
     -pp)
@@ -114,16 +110,8 @@ parse_args() {
 
 # check important variables
 check_variables() {
-    if [[ -z $KONNECT_API_URL ]]; then
-        error "Konnect API URL is missing"
-    fi
-    
-    if [[ -z $KONNECT_USERNAME ]]; then
-        error "Konnect username is missing"
-    fi
-
-    if  [[ -z $KONNECT_PASSWORD ]]; then
-        error "Konnect password is missing"
+    if [[ -z $KONNECT_CERTIFICATE_KEY ]]; then
+        error "Konnect certificate key is missing"
     fi
 
     if [[ -z $KONNECT_RUNTIME_REPO ]]; then
@@ -132,6 +120,14 @@ check_variables() {
 
     if [[ -z $KONNECT_RUNTIME_IMAGE ]]; then
         error "Konnect runtime image name is missing"
+    fi
+
+    if [[ -z $KONNECT_CP_ENDPOINT ]]; then
+        error "Konnect control plane outlet url is missing"
+    fi
+
+    if [[ -z $KONNECT_TP_ENDPOINT ]]; then
+        error "Konnect telemetry outlet url is missing"
     fi
 
     # check if it is in DEV mode and all required parameters are given

--- a/konnect-runtime-setup.sh
+++ b/konnect-runtime-setup.sh
@@ -17,7 +17,6 @@ globals() {
 
 error() {
     echo "Error: " "$@"
-    cleanup
     exit 1
 } 
 
@@ -194,6 +193,7 @@ verify_certificates() {
     CERT_HASH=$(openssl x509 -noout -modulus -in cluster.crt | openssl md5)
 
     if [[ "$KEY_HASH" != "$CERT_HASH" ]]; then
+        cleanup
         error "certificates are not valid"
     fi
 

--- a/konnect-runtime-setup.sh
+++ b/konnect-runtime-setup.sh
@@ -215,8 +215,6 @@ run_kong() {
 
     echo $KONNECT_CERTIFICATE_KEY > cluster.key
     echo $KONNECT_PUBLIC_CERTIFICATE > cluster.crt
-    chmod o+r cluster.key
-    chmod o+r cluster.crt
 
     CP_SERVER_NAME=$(echo "$KONNECT_CP_ENDPOINT" | awk -F/ '{print $3}')
     TP_SERVER_NAME=$(echo "$KONNECT_TP_ENDPOINT" | awk -F/ '{print $3}')
@@ -232,9 +230,9 @@ run_kong() {
         -e "KONG_CLUSTER_SERVER_NAME=$CP_SERVER_NAME" \
         -e "KONG_CLUSTER_TELEMETRY_ENDPOINT=$TP_SERVER_NAME:443" \
         -e "KONG_CLUSTER_TELEMETRY_SERVER_NAME=$TP_SERVER_NAME" \
-        -e "KONG_CLUSTER_CERT=cluster.crt" \
-        -e "KONG_CLUSTER_CERT_KEY=cluster.key" \
-        -e "KONG_LUA_SSL_TRUSTED_CERTIFICATE=system" \
+        -e "KONG_CLUSTER_CERT=/config/cluster.crt" \
+        -e "KONG_CLUSTER_CERT_KEY=/config/cluster.key" \
+        -e "KONG_LUA_SSL_TRUSTED_CERTIFICATE=system,/config/cluster.crt" \
         --mount type=bind,source="$(pwd)",target=/config,readonly \
         -p "$KONNECT_RUNTIME_PORT":8000 \
         -p "$KONNECT_RUNTIME_PORT_SECURE":8443 \
@@ -250,8 +248,6 @@ run_kong() {
 cleanup() {
     # remove cookie file
     rm -f ./$KONNECT_HTTP_SESSION_NAME
-    rm -f ./openssl.cnf
-    rm -f ./cluster.key
 }
 
 main() {

--- a/konnect-runtime-setup.sh
+++ b/konnect-runtime-setup.sh
@@ -220,7 +220,6 @@ run_kong() {
         -e "KONG_CLUSTER_SERVER_NAME=$CP_SERVER_NAME" \
         -e "KONG_CLUSTER_TELEMETRY_ENDPOINT=$TP_SERVER_NAME:443" \
         -e "KONG_CLUSTER_TELEMETRY_SERVER_NAME=$TP_SERVER_NAME" \
-#        -e "KONG_CLUSTER_CERT=/config/cluster.crt" \
         -e "KONG_CLUSTER_CERT_KEY=/config/cluster.key" \
         -e "KONG_LUA_SSL_TRUSTED_CERTIFICATE=system" \
         --mount type=bind,source="$(pwd)",target=/config,readonly \


### PR DESCRIPTION
https://konghq.atlassian.net/browse/KHCP-3984

Remove username and password from Runtime instance setup script, and add -key, -te, -cp params using certificate key, telemetry url, and cp outlet url.

## Demo:
Please run the following script, while replacing -key and -crt with your own generated one-line **key** and **certificate**.
`/bin/bash <(curl -fsSL 'https://raw.githubusercontent.com/Kong/konnect-runtimes/cert-quick-start/konnect-runtime-setup.sh') \
-key '<private-key>' \
-crt '<certificate>' \
-cp '<control plane outlet url>' \
-te '<telementr-url>' \
-r 'kong' \
-ri 'kong-gateway:2.8.1.3'`