### PR TITLE
feat: update kong's configuration for quick-start experience

### DIFF
--- a/konnect-runtime-setup.sh
+++ b/konnect-runtime-setup.sh
@@ -210,8 +210,7 @@ run_kong() {
     docker run -d \
         -e "KONG_ROLE=data_plane" \
         -e "KONG_DATABASE=off" \
-        -e "KONG_ANONYMOUS_REPORTS=off" \
-        -e "KONG_VITALS_TTL_DAYS=723" \
+        -e "KONG_NGINX_WORKER_PROCESSES=1" \
         -e "KONG_CLUSTER_MTLS=pki" \
         -e "KONG_CLUSTER_CONTROL_PLANE=$CP_SERVER_NAME:443" \
         -e "KONG_CLUSTER_SERVER_NAME=$CP_SERVER_NAME" \


### PR DESCRIPTION
Notable changes:
- Anonymous reports has been turned on by default to match with overall
  product experience
- Vitals settings are not relevant
- The number of worker processes has been hard-coded to '1'. This
  ensures Kong's deployment on Laptops with 4 or 8 CPU threads doesn't
  result in an egregious amount of memory consumption. This is deemed
  acceptable because 'quick-start' != 'production-ready'.