### PR TITLE
feat(analytics): turn off vitals

### DIFF
--- a/konnect-runtime-setup.sh
+++ b/konnect-runtime-setup.sh
@@ -211,6 +211,7 @@ run_kong() {
         -e "KONG_ROLE=data_plane" \
         -e "KONG_DATABASE=off" \
         -e "KONG_KONNECT_MODE=on" \
+        -e "KONG_VITALS=off" \
         -e "KONG_NGINX_WORKER_PROCESSES=1" \
         -e "KONG_CLUSTER_MTLS=pki" \
         -e "KONG_CLUSTER_CONTROL_PLANE=$CP_SERVER_NAME:443" \


### PR DESCRIPTION
When enabling Konnect_mode in previous PR I saw double counting while testing and realized the DP was running with both analytics and vitals. Updated to turn off vitals in 3.0 runtime script