### PR TITLE
fix: move flight number output to after kong image pulling output [KHCP-4842]

### DIFF
--- a/konnect-runtime-setup.sh
+++ b/konnect-runtime-setup.sh
@@ -229,8 +229,7 @@ run_kong() {
         error "failed to start a runtime"
     fi
 
-    echo -n "Your flight number: "
-    echo "$FLIGHT_NUMBER"
+    echo "Your flight number: $FLIGHT_NUMBER"
 
     log_debug "=> kong gateway container starting phase completed"
 }

--- a/konnect-runtime-setup.sh
+++ b/konnect-runtime-setup.sh
@@ -206,8 +206,7 @@ run_kong() {
     CP_SERVER_NAME=$(echo "$KONNECT_CP_ENDPOINT" | awk -F/ '{print $3}')
     TP_SERVER_NAME=$(echo "$KONNECT_TP_ENDPOINT" | awk -F/ '{print $3}')
 
-    echo -n "Your flight number: "
-    docker run -d \
+    FLIGHT_NUMBER=$(docker run -d \
         -e "KONG_ROLE=data_plane" \
         -e "KONG_DATABASE=off" \
         -e "KONG_KONNECT_MODE=on" \
@@ -224,11 +223,14 @@ run_kong() {
         --mount type=bind,source="$(pwd)",target=/config,readonly \
         -p "$KONNECT_RUNTIME_PORT":8000 \
         -p "$KONNECT_RUNTIME_PORT_SECURE":8443 \
-        "$KONNECT_RUNTIME_REPO"/"$KONNECT_RUNTIME_IMAGE"
+        "$KONNECT_RUNTIME_REPO"/"$KONNECT_RUNTIME_IMAGE")
 
     if [[ $? -gt 0 ]]; then
         error "failed to start a runtime"
     fi
+
+    echo -n "Your flight number: "
+    echo "$FLIGHT_NUMBER"
 
     log_debug "=> kong gateway container starting phase completed"
 }


### PR DESCRIPTION
https://konghq.atlassian.net/browse/KHCP-4842

Rearrange output message in setup script, to ensure flight number is printed after all messages from docker run command is finished. 
![image](https://user-images.githubusercontent.com/14229640/199143797-70274f18-58e2-4fd6-9ac7-0602401bdcfe.png)
